### PR TITLE
initial ConfigurationService

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,18 @@ lint-fix: node_modules
 run: node_modules
 	npm run start
 
+.PHONY: build-main
+build-main: node_modules
+	npm run build:main
+
+.PHONY: build-renderer
+build-renderer: node_modules
+	npm run build:renderer
+
 .PHONY: test
-test: node_modules
+test: node_modules \
+		build-main \
+		build-renderer
 	npm run test
 
 .PHONY: package

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
         "@types/jest": "^27.5.1",
+        "@types/lodash": "^4.14.182",
         "@types/node": "17.0.33",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
@@ -2090,6 +2091,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -18320,6 +18327,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,35 +1,25 @@
 {
-  "description": "A foundation for scalable desktop apps",
-  "keywords": [
-    "electron",
-    "boilerplate",
-    "react",
-    "typescript",
-    "ts",
-    "sass",
-    "webpack",
-    "hot",
-    "reload"
-  ],
-  "homepage": "https://github.com/electron-react-boilerplate/electron-react-boilerplate#readme",
+  "description": "note-taking app",
+  "keywords": ["markdown"],
+  "homepage": "https://github.com/aviau/noteapp",
   "bugs": {
-    "url": "https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues"
+    "url": "https://github.com/aviau/noteapp/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/electron-react-boilerplate/electron-react-boilerplate.git"
+    "url": "git+https://github.com/aviau/noteapp.git"
   },
   "license": "MIT",
   "author": {
-    "name": "Electron React Boilerplate Maintainers",
-    "email": "electronreactboilerplate@gmail.com",
-    "url": "https://electron-react-boilerplate.js.org"
+    "name": "Sophie Bernadin-Mercier",
+    "email": "sophiebmercier@hotmail.com",
+    "url": "https://github.com/Shuhala"
   },
   "contributors": [
     {
-      "name": "Amila Welihinda",
-      "email": "amilajack@gmail.com",
-      "url": "https://github.com/amilajack"
+      "name": "Alexandre Viau",
+      "email": "alexandre@alexandreviau.net",
+      "url": "https://alexandreviau.net"
     }
   ],
   "main": "./src/main/main.ts",
@@ -186,8 +176,8 @@
     "webpack-merge": "^5.8.0"
   },
   "build": {
-    "productName": "ElectronReact",
-    "appId": "org.erb.ElectronReact",
+    "productName": "noteapp",
+    "appId": "net.alexandrevieu.noteapp",
     "asar": true,
     "asarUnpack": "**\\*.{node,dll}",
     "files": [

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@types/jest": "^27.5.1",
+    "@types/lodash": "^4.14.182",
     "@types/node": "17.0.33",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",

--- a/src/common/asserts.ts
+++ b/src/common/asserts.ts
@@ -1,0 +1,3 @@
+export const assertUnreachable = (x: never): never => {
+  throw new Error(`Didn't expect to get here: ${x}`);
+};

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -4,16 +4,16 @@
  */
 export enum IpcChannel {
   /* Ping the Main thread */
-  MAIN_PING = 'main:utils:ping',
-  MAIN_PING_REPLY = 'renderer:utils:pong',
+  MAIN_UTILS_PING = 'main:utils:ping',
+  MAIN_UTILS_PING_REPLY = 'main:utils:ping:reply',
 }
 
 export interface IpcChannelMessage<T extends IpcChannel> {
-  data: T extends IpcChannel.MAIN_PING
+  data: T extends IpcChannel.MAIN_UTILS_PING
     ? {
         message: string;
       }
-    : T extends IpcChannel.MAIN_PING_REPLY
+    : T extends IpcChannel.MAIN_UTILS_PING_REPLY
     ? {
         reply: string;
       }

--- a/src/common/tests/utils.ts
+++ b/src/common/tests/utils.ts
@@ -1,0 +1,9 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+export async function tempDir() {
+  const osTempDir = os.tmpdir();
+  const dir = await fs.mkdtemp(path.join(osTempDir, 'noteapp'));
+  return dir;
+}

--- a/src/main/configuration/configurationItem.ts
+++ b/src/main/configuration/configurationItem.ts
@@ -1,0 +1,20 @@
+export enum ConfigurationKey {
+  VAULT = 'vault',
+  DEBUG = 'debug',
+}
+
+export interface VaultConfiguration {
+  key: ConfigurationKey.VAULT;
+  data: {
+    current: string;
+  };
+}
+
+export interface DebugConfiguration {
+  key: ConfigurationKey.DEBUG;
+  data: {
+    enabled: boolean;
+  };
+}
+
+export type ConfigurationItem = VaultConfiguration | DebugConfiguration;

--- a/src/main/configuration/configurationService.ts
+++ b/src/main/configuration/configurationService.ts
@@ -1,0 +1,125 @@
+import lodash from 'lodash';
+import fs from 'fs/promises';
+import path from 'path';
+import { assertUnreachable } from '../../common/asserts';
+import {
+  ConfigurationItem,
+  ConfigurationKey,
+  DebugConfiguration,
+  VaultConfiguration,
+} from './configurationItem';
+
+export class ConfigurationService {
+  userDataPath: string;
+
+  constructor(userDataPath: string) {
+    this.userDataPath = userDataPath;
+  }
+
+  async setConfiguration(item: ConfigurationItem): Promise<void> {
+    const configurationObject = await this.loadSettingsJson();
+    configurationObject[item.key] = item.data;
+    await this.saveSettingsJson(configurationObject);
+  }
+
+  async getVaultConfiguration(): Promise<VaultConfiguration> {
+    const config = await this.getConfiguration(ConfigurationKey.VAULT);
+    return config as VaultConfiguration;
+  }
+
+  async getDebugConfiguration(): Promise<DebugConfiguration> {
+    const config = await this.getConfiguration(ConfigurationKey.DEBUG);
+    return config as DebugConfiguration;
+  }
+
+  private async getConfiguration(
+    key: ConfigurationKey
+  ): Promise<ConfigurationItem> {
+    const configurationObject = await this.loadSettingsJson();
+
+    let configurationData = configurationObject[key] || {};
+
+    // There could be missing keys, add them.
+    configurationData = lodash.mergeWith(
+      this.defaultConfiguration(key).data,
+      configurationData,
+      (_, b) => {
+        return lodash.isArray(b) ? b : undefined;
+      }
+    );
+
+    const configurationItem = {
+      key,
+      data: configurationData,
+    } as ConfigurationItem;
+
+    return configurationItem;
+  }
+
+  // Get the default configuration item for a given key.
+  private defaultConfiguration(key: ConfigurationKey): ConfigurationItem {
+    switch (key) {
+      case ConfigurationKey.VAULT:
+        return {
+          key: ConfigurationKey.VAULT,
+          data: {
+            current: '',
+          },
+        };
+      case ConfigurationKey.DEBUG:
+        return {
+          key: ConfigurationKey.DEBUG,
+          data: {
+            enabled: false,
+          },
+        };
+      default:
+        return assertUnreachable(key);
+    }
+  }
+
+  async ensureSettingsDir(): Promise<void> {
+    try {
+      await fs.stat(this.userDataPath);
+    } catch (error) {
+      const err = error as any;
+      if (err.code !== 'ENOENT') {
+        throw error;
+      }
+      await fs.mkdir(this.userDataPath);
+    }
+  }
+
+  async ensureSettingsFile(): Promise<void> {
+    await this.ensureSettingsDir();
+    const settingsFilePath = this.getSettingsFilePath();
+    try {
+      await fs.stat(settingsFilePath);
+    } catch (error) {
+      const err = error as any;
+      if (err.code !== 'ENOENT') {
+        throw error;
+      }
+      await fs.writeFile(settingsFilePath, '{}');
+    }
+  }
+
+  private getSettingsFilePath(): string {
+    return path.join(this.userDataPath, 'settings.json');
+  }
+
+  private async loadSettingsJson(): Promise<any> {
+    await this.ensureSettingsFile();
+    const filePath = this.getSettingsFilePath();
+    const fileData = await fs.readFile(filePath, 'utf-8');
+    const settingsObject = JSON.parse(fileData);
+    return settingsObject;
+  }
+
+  private async saveSettingsJson(settings: object): Promise<void> {
+    await this.ensureSettingsFile();
+    const filePath = this.getSettingsFilePath();
+    const fileData = JSON.stringify(settings, null, 4);
+    await fs.writeFile(filePath, fileData);
+  }
+}

--- a/src/main/configuration/index.ts
+++ b/src/main/configuration/index.ts
@@ -1,0 +1,4 @@
+import { ConfigurationService } from './configurationService';
+import { ConfigurationKey } from './configurationItem';
+
+export { ConfigurationService, ConfigurationKey };

--- a/src/main/configuration/index.ts
+++ b/src/main/configuration/index.ts
@@ -1,4 +1,2 @@
-import { ConfigurationService } from './configurationService';
-import { ConfigurationKey } from './configurationItem';
-
-export { ConfigurationService, ConfigurationKey };
+export { ConfigurationService } from './configurationService';
+export { ConfigurationKey } from './configurationItem';

--- a/src/main/configuration/tests/configurationServices.test.ts
+++ b/src/main/configuration/tests/configurationServices.test.ts
@@ -1,0 +1,33 @@
+import path from 'path';
+import { ConfigurationService, ConfigurationKey } from '..';
+import { tempDir } from '../../../common/tests/utils';
+
+test('vault has a default config', async () => {
+  const dir = path.join(await tempDir(), 'test');
+  const service = new ConfigurationService(dir);
+  const loadedItem = await service.getVaultConfiguration();
+  expect(loadedItem).toEqual({
+    key: ConfigurationKey.VAULT,
+    data: {
+      current: '',
+    },
+  });
+});
+
+test('save and load a config object', async () => {
+  const dir = path.join(await tempDir(), 'test');
+  const service = new ConfigurationService(dir);
+  await service.setConfiguration({
+    key: ConfigurationKey.VAULT,
+    data: {
+      current: 'copina',
+    },
+  });
+  const loadedItem = await service.getVaultConfiguration();
+  expect(loadedItem).toEqual({
+    key: ConfigurationKey.VAULT,
+    data: {
+      current: 'copina',
+    },
+  });
+});

--- a/src/main/ipcMainConnection/ipcMainConnection.ts
+++ b/src/main/ipcMainConnection/ipcMainConnection.ts
@@ -32,7 +32,7 @@ export class IpcMainConnection {
     this.ipcMain = ipcMain;
   }
 
-  onPing(callback: IpcMainConnectionCallback<IpcChannel.MAIN_PING>) {
-    on(this.ipcMain, IpcChannel.MAIN_PING, callback);
+  onPing(callback: IpcMainConnectionCallback<IpcChannel.MAIN_UTILS_PING>) {
+    on(this.ipcMain, IpcChannel.MAIN_UTILS_PING, callback);
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -28,6 +28,7 @@ class AppUpdater {
 let mainWindow: BrowserWindow | null = null;
 
 export const noteApplication = new NoteApplication(
+  app,
   new IpcMainConnection(ipcMain)
 );
 

--- a/src/renderer/ipcRendererConnection.ts
+++ b/src/renderer/ipcRendererConnection.ts
@@ -6,7 +6,7 @@ import { IpcChannel, IpcChannelMessage } from '../common/ipc';
 export class IpcRendererConnection {
   constructor() {
     window.electron.ipcRenderer.on(
-      IpcChannel.MAIN_PING_REPLY,
+      IpcChannel.MAIN_UTILS_PING_REPLY,
       this.onMainPingReply
     );
   }
@@ -19,11 +19,11 @@ export class IpcRendererConnection {
   }
 
   mainPing(): void {
-    this.sendMessage(IpcChannel.MAIN_PING, { data: { message: 'ping' } });
+    this.sendMessage(IpcChannel.MAIN_UTILS_PING, { data: { message: 'ping' } });
   }
 
   private onMainPingReply(
-    message: IpcChannelMessage<IpcChannel.MAIN_PING_REPLY>
+    message: IpcChannelMessage<IpcChannel.MAIN_UTILS_PING_REPLY>
   ): void {
     console.log(`Got Ping Reply: ${message.data.reply}`);
   }


### PR DESCRIPTION
- Create ConfigurationService
- It can read and write to a config file (currently at `~/.config/Electron`)
- Config keys are typed.
- I have updated the startup `pong` to include the id of the currently open vault.

Loosely inspired from https://github.com/nathanbuchar/electron-settings, but:
- Uses the fs/promises API
- Does not depend on electron.