### PR TITLE
main ipc: implement invoke API

### DIFF
--- a/src/common/ipcMain.ts
+++ b/src/common/ipcMain.ts
@@ -1,9 +1,18 @@
+// This file describes the MAIN <--> RENDERER IPC.
+//
+// It has type definitions for:
+// - Channels
+// - Messages
+// - Responses
+//
+// The IPC is used to communicate with the main process from
+// the two renderer processes: Worker and Ui.
+
 // Channels for communications between processes. For clarity,
 // channels are one-way and prefixed by the original destination.
 export enum IpcChannel {
   // Ping the main process
   MAIN_UTILS_PING = 'main:utils:ping',
-  MAIN_UTILS_PING_REPLY = 'main:utils:ping:reply',
 
   // Send logs to the main process. Mostly for debugging.
   MAIN_UTILS_LOG = 'main:utils:log',
@@ -16,18 +25,24 @@ export enum IpcChannel {
   RENDERER_IPC_SET_CHANNEL = 'renderer:ipc:set-channel',
 }
 
+// Message interfaces for each of the channels.
 export interface IpcChannelMessage<T extends IpcChannel> {
   data: T extends IpcChannel.MAIN_UTILS_PING
     ? {
         message: string;
       }
-    : T extends IpcChannel.MAIN_UTILS_PING_REPLY
-    ? {
-        reply: string;
-      }
     : T extends IpcChannel.MAIN_UTILS_LOG
     ? {
         message: string;
+      }
+    : null;
+}
+
+// Some channels can have responses.
+export interface IpcChannelResponse<T extends IpcChannel> {
+  data: T extends IpcChannel.MAIN_UTILS_PING
+    ? {
+        reply: string;
       }
     : null;
 }

--- a/src/main/services/ipc/index.ts
+++ b/src/main/services/ipc/index.ts
@@ -1,4 +1,3 @@
-import { IpcMainConnection } from './ipcMainConnection';
-import { IpcMainConnectionEvent } from './ipcMainConnectionEvent';
-
-export { IpcMainConnection, IpcMainConnectionEvent };
+export { IpcMainConnection } from './ipcMainConnection';
+export { IpcMainConnectionEvent } from './ipcMainConnectionEvent';
+export { IpcMainConnectionInvokeEvent } from './ipcMainConnectionInvokeEvent';

--- a/src/main/services/ipc/ipcMainConnectionEvent.ts
+++ b/src/main/services/ipc/ipcMainConnectionEvent.ts
@@ -1,10 +1,10 @@
 import Electron from 'electron';
 
-import { IpcChannel, IpcChannelMessage } from '../../../common/ipc';
+import { IpcChannel, IpcChannelMessage } from '../../../common/ipcMain';
 
-// Minimal IpcMainEvent exposed by IpcMainConnection's APIs.
+// Minimal IpcMainEvent
 export class IpcMainConnectionEvent {
-  event: Electron.IpcMainEvent;
+  private event: Electron.IpcMainEvent;
 
   constructor(event: Electron.IpcMainEvent) {
     this.event = event;

--- a/src/main/services/ipc/ipcMainConnectionInvokeEvent.ts
+++ b/src/main/services/ipc/ipcMainConnectionInvokeEvent.ts
@@ -1,0 +1,11 @@
+import Electron from 'electron';
+
+// Minimal IpcMainInvokeEvent
+export class IpcMainConnectionInvokeEvent {
+  private event: Electron.IpcMainInvokeEvent;
+
+  constructor(event: Electron.IpcMainInvokeEvent) {
+    // Let's wait until there is a need before exposing anything here.
+    this.event = event;
+  }
+}

--- a/src/ui/preload.d.ts
+++ b/src/ui/preload.d.ts
@@ -1,4 +1,8 @@
-import { IpcChannel, IpcChannelMessage } from '../common/ipc';
+import {
+  IpcChannel,
+  IpcChannelMessage,
+  IpcChannelResponse,
+} from '../common/ipcMain';
 
 declare global {
   interface Window {
@@ -12,6 +16,10 @@ declare global {
           channel: T,
           callback: (message: IpcChannelMessage<T>) => void
         ): (() => void) | undefined;
+        invoke<T extends IpcChannel>(
+          channel: T,
+          message: IpcChannelMessage<T>
+        ): Promise<IpcChannelResponse<T>>;
       };
     };
   }

--- a/src/ui/services/ipc/ipcRendererConnection.ts
+++ b/src/ui/services/ipc/ipcRendererConnection.ts
@@ -1,16 +1,13 @@
-import { IpcChannel, IpcChannelMessage } from '../../../common/ipc';
+import {
+  IpcChannel,
+  IpcChannelMessage,
+  IpcChannelResponse,
+} from '../../../common/ipcMain';
 
 /*
  * Responsible for all communications with the main process.
  */
 export class IpcRendererConnection {
-  constructor() {
-    window.electron.ipcRenderer.on(
-      IpcChannel.MAIN_UTILS_PING_REPLY,
-      this.onMainPingReply
-    );
-  }
-
   private sendMessage<T extends IpcChannel>(
     channel: T,
     message: IpcChannelMessage<T>
@@ -18,8 +15,18 @@ export class IpcRendererConnection {
     window.electron.ipcRenderer.sendMessage(channel, message);
   }
 
-  mainPing(): void {
-    this.sendMessage(IpcChannel.MAIN_UTILS_PING, { data: { message: 'ping' } });
+  private async invoke<T extends IpcChannel>(
+    channel: T,
+    message: IpcChannelMessage<T>
+  ): Promise<IpcChannelResponse<T>> {
+    return window.electron.ipcRenderer.invoke(channel, message);
+  }
+
+  async mainPing(): Promise<void> {
+    const message = await this.invoke(IpcChannel.MAIN_UTILS_PING, {
+      data: { message: 'ping' },
+    });
+    console.log(`[UI] got mainPing Reply: ${message.data.reply}`);
   }
 
   mainLog(message: string): void {
@@ -30,11 +37,5 @@ export class IpcRendererConnection {
     this.sendMessage(IpcChannel.MAIN_IPC_REQUEST_CHANNEL_REFRESH, {
       data: null,
     });
-  }
-
-  private onMainPingReply(
-    message: IpcChannelMessage<IpcChannel.MAIN_UTILS_PING_REPLY>
-  ): void {
-    console.log(`Got Ping Reply: ${message.data.reply}`);
   }
 }

--- a/src/ui/uiMain.ts
+++ b/src/ui/uiMain.ts
@@ -1,4 +1,4 @@
-import { IpcChannel } from '../common/ipc';
+import { IpcChannel } from '../common/ipcMain';
 import { IpcRendererConnection } from './services/ipc/ipcRendererConnection';
 
 export class UiMain {

--- a/src/worker/preload.d.ts
+++ b/src/worker/preload.d.ts
@@ -1,4 +1,8 @@
-import { IpcChannel, IpcChannelMessage } from '../common/ipc';
+import {
+  IpcChannel,
+  IpcChannelMessage,
+  IpcChannelResponse,
+} from '../common/ipcMain';
 
 declare global {
   interface Window {
@@ -12,6 +16,10 @@ declare global {
           channel: T,
           callback: (message: IpcChannelMessage<T>) => void
         ): (() => void) | undefined;
+        invoke<T extends IpcChannel>(
+          channel: T,
+          message: IpcChannelMessage<T>
+        ): Promise<IpcChannelResponse<T>>;
       };
     };
   }

--- a/src/worker/services/ipc/ipcWorkerConnection.ts
+++ b/src/worker/services/ipc/ipcWorkerConnection.ts
@@ -1,4 +1,4 @@
-import { IpcChannel, IpcChannelMessage } from '../../../common/ipc';
+import { IpcChannel, IpcChannelMessage } from '../../../common/ipcMain';
 
 /*
  * Responsible for all communications with the main process.

--- a/src/worker/workerMain.ts
+++ b/src/worker/workerMain.ts
@@ -1,4 +1,4 @@
-import { IpcChannel } from '../common/ipc';
+import { IpcChannel } from '../common/ipcMain';
 import { IpcWorkerConnection } from './services/ipc/ipcWorkerConnection';
 
 export class WorkerMain {


### PR DESCRIPTION
The main `ping` response can be made via the `invoke` API instead of using channels.

Looks much cleaner. Channels can now be associated with a message and a response.

Also: I remembered `private` was thing for class variables and adjusted some :upside_down_face: 