### PR TITLE
utils/paths: pathFor utility

### DIFF
--- a/src/ui/foundation/MainLayout/data.tsx
+++ b/src/ui/foundation/MainLayout/data.tsx
@@ -12,8 +12,7 @@ import { TreeItem, TreeView } from '@mui/lab';
 import { IconButton, TextField, Typography } from '@mui/material';
 import { useContext } from 'react';
 import { useNavigate, NavLink } from 'react-router-dom';
-
-import { paths } from '../../utilities';
+import { pathFor, PathName } from 'src/ui/utilities/paths';
 import { ThemeContext } from '../ThemeProvider';
 
 function FolderView() {
@@ -30,7 +29,12 @@ function FolderView() {
           nodeId="2"
           label="day1"
           onClick={() =>
-            navigate(`${paths.markdown}?filepath=journals/day1.md`)
+            navigate(
+              pathFor({
+                path: PathName.PAGES,
+                params: { filepath: 'journals/day1.md' },
+              })
+            )
           }
         />
       </TreeItem>
@@ -40,14 +44,24 @@ function FolderView() {
             nodeId="8"
             label="Alex"
             onClick={() =>
-              navigate(`${paths.markdown}?filepath=pages/meetings/alex.md`)
+              navigate(
+                pathFor({
+                  path: PathName.PAGES,
+                  params: { filepath: 'pages/meetings/alex.md' },
+                })
+              )
             }
           />
           <TreeItem
             nodeId="9"
             label="Fidji"
             onClick={() =>
-              navigate(`${paths.markdown}?filepath=pages/meetings/fidji.md`)
+              navigate(
+                pathFor({
+                  path: PathName.PAGES,
+                  params: { filepath: 'pages/meetings/fidji.md' },
+                })
+              )
             }
           />
         </TreeItem>
@@ -55,7 +69,12 @@ function FolderView() {
           nodeId="10"
           label="How to take notes"
           onClick={() =>
-            navigate(`${paths.markdown}?filepath=pages/how-to-take-notes.md`)
+            navigate(
+              pathFor({
+                path: PathName.PAGES,
+                params: { filepath: 'pages/how-to-take-notes.md' },
+              })
+            )
           }
         />
       </TreeItem>
@@ -77,7 +96,7 @@ export const menuItems = [
   {
     id: 'Dashboard',
     icon: (
-      <IconButton component={NavLink} to="/">
+      <IconButton component={NavLink} to={pathFor({ path: PathName.HOME })}>
         <Dashboard />
       </IconButton>
     ),

--- a/src/ui/foundation/routes.tsx
+++ b/src/ui/foundation/routes.tsx
@@ -1,5 +1,6 @@
 import { Navigate } from 'react-router-dom';
 
+import { PathName } from 'src/ui/utilities/paths';
 import { Editor, HelloWorld, NotFound } from '../sections';
 import { MainLayout } from './MainLayout';
 
@@ -8,18 +9,27 @@ const routes = () => [
     path: '/',
     element: <MainLayout />,
     children: [
-      { path: '', element: <HelloWorld name="copain" /> },
       {
-        path: 'pages',
+        path: PathName.HOME,
+        element: <HelloWorld name="copain" />,
+      },
+      {
+        path: PathName.PAGES,
         element: <Editor />,
       },
-      { path: '404', element: <NotFound /> },
-      { path: '*', element: <Navigate to="/404" /> },
+      {
+        path: '404',
+        element: <NotFound />,
+      },
+      {
+        path: '*',
+        element: <Navigate to="404" />,
+      },
     ],
   },
   {
     // TODO: redirect default path on startup
-    path: '/index.html',
+    path: 'index.html',
     element: <Navigate to="/" />,
   },
 ];

--- a/src/ui/utilities/index.ts
+++ b/src/ui/utilities/index.ts
@@ -1,1 +1,1 @@
-export { paths } from './paths';
+export { pathFor, PathName } from './paths';

--- a/src/ui/utilities/paths.ts
+++ b/src/ui/utilities/paths.ts
@@ -1,5 +1,28 @@
-// TODO: find elegant way to manage paths from foundation/routes.tsx
-export const paths = {
-  helloWorld: '/',
-  markdown: '/pages',
-};
+export enum PathName {
+  HOME = '',
+  PAGES = 'pages',
+}
+
+export type PathAndParams =
+  | {
+      path: PathName.HOME;
+      params?: undefined;
+    }
+  | {
+      path: PathName.PAGES;
+      params?: {
+        filepath?: string;
+      };
+    };
+
+export function pathFor({ path, params }: PathAndParams): string {
+  const paramsEncoder = new URLSearchParams();
+  if (params !== undefined) {
+    Object.entries(params).forEach(([name, param]) => {
+      if (param !== undefined) {
+        paramsEncoder.append(name, param);
+      }
+    });
+  }
+  return `/${path}?${paramsEncoder.toString()}`;
+}


### PR DESCRIPTION
more lightweight than adding a typed router library, but provides most of the type safety.

When you generate a route, just use `routeFor`.

Then all you have to do is keep the params interface for each route in sync with how its used, and it will make sure that all references to that route in the app are correctly used.