### PR TITLE
ipc: less verbose messages

### DIFF
--- a/src/lib/ipcMain.ts
+++ b/src/lib/ipcMain.ts
@@ -44,27 +44,33 @@ export enum IpcMainChannel {
 }
 
 // Message interfaces for each of the channels.
-export interface IpcMainChannelMessage<T extends IpcMainChannel> {
-  data: T extends IpcMainChannel.MAIN_UTILS_PING
+export type IpcMainChannelMessage<T extends IpcMainChannel> =
+  T extends IpcMainChannel.MAIN_UTILS_PING
     ? {
-        message: string;
+        data: {
+          message: string;
+        };
       }
     : T extends IpcMainChannel.MAIN_UTILS_LOG
     ? {
-        message: string;
+        data: {
+          message: string;
+        };
       }
     : null;
-}
 
 // Some channels can have responses.
-export interface IpcMainChannelResponse<T extends IpcMainChannel> {
-  data: T extends IpcMainChannel.MAIN_UTILS_PING
+export type IpcMainChannelResponse<T extends IpcMainChannel> =
+  T extends IpcMainChannel.MAIN_UTILS_PING
     ? {
-        reply: string;
+        data: {
+          reply: string;
+        };
       }
     : T extends IpcMainChannel.MAIN_UTILS_GET_USER_DATA_PATH
     ? {
-        path: string;
+        data: {
+          path: string;
+        };
       }
     : null;
-}

--- a/src/main/noteMain.ts
+++ b/src/main/noteMain.ts
@@ -121,24 +121,16 @@ export class NoteMain {
     const { port1, port2 } = new MessageChannelMain();
 
     // Provide it to the workerIpcMainChannel
-    const workerMessage: IpcMainChannelMessage<IpcMainChannel.RENDERER_IPC_SET_CHANNEL> =
-      {
-        data: null,
-      };
     workerWindow.webContents.postMessage(
       IpcMainChannel.RENDERER_IPC_SET_CHANNEL,
-      workerMessage,
+      null,
       [port1]
     );
 
     // Povide it to the UI.IpcMainChannel
-    const uiMessage: IpcMainChannelMessage<IpcMainChannel.RENDERER_IPC_SET_CHANNEL> =
-      {
-        data: null,
-      };
     uiWindow.webContents.postMessage(
       IpcMainChannel.RENDERER_IPC_SET_CHANNEL,
-      uiMessage,
+      null,
       [port2]
     );
   }

--- a/src/ui/services/ipc/ipcUiService.ts
+++ b/src/ui/services/ipc/ipcUiService.ts
@@ -54,9 +54,7 @@ export class IpcUiService {
   }
 
   private refreshChannels(): void {
-    this.mainSendMessage(IpcMainChannel.MAIN_IPC_REQUEST_CHANNEL_REFRESH, {
-      data: null,
-    });
+    this.mainSendMessage(IpcMainChannel.MAIN_IPC_REQUEST_CHANNEL_REFRESH, null);
   }
 
   private async onSetWorkerChannel(workerChannel: MessagePort): Promise<void> {

--- a/src/worker/services/ipc/ipcWorkerService.ts
+++ b/src/worker/services/ipc/ipcWorkerService.ts
@@ -67,13 +67,11 @@ export class IpcWorkerService {
   }
 
   mainQuit(): void {
-    this.mainSendMessage(IpcMainChannel.MAIN_UTILS_QUIT, { data: null });
+    this.mainSendMessage(IpcMainChannel.MAIN_UTILS_QUIT, null);
   }
 
   mainRefreshChannels(): void {
-    this.mainSendMessage(IpcMainChannel.MAIN_IPC_REQUEST_CHANNEL_REFRESH, {
-      data: null,
-    });
+    this.mainSendMessage(IpcMainChannel.MAIN_IPC_REQUEST_CHANNEL_REFRESH, null);
   }
 
   private async onSetUiChannel(event: IpcRendererEvent): Promise<void> {
@@ -116,9 +114,7 @@ export class IpcWorkerService {
   async mainUtilsGetUserDataPath(): Promise<string> {
     const resp = await this.mainInvoke(
       IpcMainChannel.MAIN_UTILS_GET_USER_DATA_PATH,
-      {
-        data: null,
-      }
+      null
     );
     return resp.data.path;
   }


### PR DESCRIPTION
Uses [conditional types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) at the type-level instead of at the field-level, making the messages lighter.

This replaces some `{data: null}` with `null`.