### PR TITLE
Render top and bottom items in SideMenu

### DIFF
--- a/src/ui/foundation/MainLayout/MainLayout.tsx
+++ b/src/ui/foundation/MainLayout/MainLayout.tsx
@@ -19,8 +19,7 @@ const MainContainer = styled(Box)(() => ({
 }));
 
 export function MainLayout() {
-  const leftMenuItems = [
-    ...menuItems,
+  const leftBottomItems = [
     {
       id: 'Settings',
       icon: <SettingsIconButton />,
@@ -32,7 +31,8 @@ export function MainLayout() {
       <TopBar />
       <MainContainer>
         <SideMenu
-          menuItems={leftMenuItems}
+          topItems={menuItems}
+          bottomItems={leftBottomItems}
           tabItems={leftTabItems}
           anchor="left"
           defaultOpen
@@ -41,7 +41,7 @@ export function MainLayout() {
           <Outlet />
         </Box>
         <SideMenu
-          menuItems={menuItems}
+          topItems={menuItems}
           tabItems={rightTabItems}
           anchor="right"
         />

--- a/src/ui/foundation/MainLayout/components/SideMenu/SideMenu.tsx
+++ b/src/ui/foundation/MainLayout/components/SideMenu/SideMenu.tsx
@@ -17,6 +17,8 @@ const ListDynamicColor = styled(List, {
   shouldForwardProp: (prop) => prop !== 'open',
 })<{ open: boolean }>(({ theme, open }) => ({
   height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
   backgroundColor: open
     ? theme.palette.secondary.dark
     : theme.palette.secondary.main,
@@ -31,14 +33,16 @@ export type MenuItem = {
 };
 
 interface Props {
-  menuItems: MenuItem[];
+  topItems?: MenuItem[];
+  bottomItems?: MenuItem[];
   tabItems: TabItem[];
   anchor: 'left' | 'right';
   defaultOpen?: boolean;
 }
 
 export function SideMenu({
-  menuItems,
+  topItems,
+  bottomItems,
   tabItems,
   anchor,
   defaultOpen = false,
@@ -64,11 +68,17 @@ export function SideMenu({
         flexDirection: anchor === 'left' ? 'row' : 'row-reverse',
       }}
     >
-      <ListDynamicColor open={open}>
-        <ListItem disablePadding>
+      <ListDynamicColor open={open} sx={{ pb: theme.spacing(10) }}>
+        <ListItem disablePadding sx={{ mb: theme.spacing(2) }}>
           <IconButton onClick={toggleDrawer}>{renderChevron()}</IconButton>
         </ListItem>
-        {menuItems.map(({ id, icon }) => (
+        {topItems?.map(({ id, icon }) => (
+          <ListItem key={id} disablePadding>
+            {icon}
+          </ListItem>
+        ))}
+        <Box sx={{ flex: 1 }} />
+        {bottomItems?.map(({ id, icon }) => (
           <ListItem key={id} disablePadding>
             {icon}
           </ListItem>


### PR DESCRIPTION
Split `SideMenu.menuItems` to accept top and bottom items.

![image](https://user-images.githubusercontent.com/22331097/180661386-0992df60-4054-4c1c-8288-bfc5fd5a2e6e.png)
