### PR TITLE
Add Command Palette

### DIFF
--- a/src/ui/foundation/App.tsx
+++ b/src/ui/foundation/App.tsx
@@ -1,11 +1,12 @@
 import CssBaseline from '@mui/material/CssBaseline';
 import { useRoutes } from 'react-router-dom';
 
+import { CommandPalette } from './CommandPalette';
 import { GlobalCommands } from './GlobalCommands';
-import { SettingsProvider } from './SettingsProvider';
 import { GlobalStateProvider } from './GlobalStateProvider';
-import { ThemeProvider } from './ThemeProvider';
 import { QueryClientProvider } from './QueryClientProvider';
+import { SettingsProvider } from './SettingsProvider';
+import { ThemeProvider } from './ThemeProvider';
 
 import routes from './routes';
 
@@ -20,6 +21,7 @@ export default function App() {
             <GlobalCommands />
             <CssBaseline />
             {routing}
+            <CommandPalette />
           </ThemeProvider>
         </SettingsProvider>
       </GlobalStateProvider>

--- a/src/ui/foundation/CommandPalette/CommandPalette.tsx
+++ b/src/ui/foundation/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,94 @@
+import {
+  Box,
+  Chip,
+  ListItemText,
+  MenuItem,
+  MenuList,
+  Modal,
+  TextField,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { isEmpty } from 'lodash';
+import React, { useContext, useState } from 'react';
+
+import { Command, SettingsContext } from '@/ui/foundation/SettingsProvider';
+import { useCommandListener } from '@/ui/hooks';
+import { hotkeyToString } from '@/ui/utilities';
+
+// TODO: Transform this component into a plugin
+// TODO: Fix keyboard accessibility
+export function CommandPalette() {
+  const theme = useTheme();
+  const { settings } = useContext(SettingsContext);
+  const [open, setOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  // TODO: define command id somewhere
+  useCommandListener('command_palette', handleOpen, handleClose);
+
+  const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFilterValue(event.target.value);
+  };
+
+  const handleCommandClick = (command: Command) => {
+    if (command.callback) {
+      command.callback();
+    }
+    setOpen(false);
+  };
+
+  const commands = settings.commands.filter((command) =>
+    command.name.toLowerCase().includes(filterValue.toLowerCase())
+  );
+
+  return (
+    <Modal open={open} onClose={handleClose}>
+      <Box
+        sx={{
+          position: 'absolute' as const,
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          width: '70vw',
+          p: theme.spacing(2),
+          bgcolor: theme.palette.background.default,
+        }}
+      >
+        <TextField
+          placeholder="Filter..."
+          variant="outlined"
+          size="small"
+          fullWidth
+          onChange={handleFilterChange}
+          sx={{ mb: 2 }}
+        />
+        <MenuList>
+          {commands.map((command) => (
+            <MenuItem
+              key={command.id}
+              onClick={() => handleCommandClick(command)}
+            >
+              <ListItemText>{command.name}</ListItemText>
+              {command.hotkeys?.map((hotkey) => (
+                <Chip
+                  key={hotkeyToString(hotkey)}
+                  label={hotkeyToString(hotkey)}
+                  color="secondary"
+                />
+              ))}
+            </MenuItem>
+          ))}
+          {isEmpty(commands) && (
+            <Typography variant="body2" color="text.secondary" align="center">
+              No commands found.
+            </Typography>
+          )}
+        </MenuList>
+      </Box>
+    </Modal>
+  );
+}

--- a/src/ui/foundation/CommandPalette/index.ts
+++ b/src/ui/foundation/CommandPalette/index.ts
@@ -1,0 +1,1 @@
+export { CommandPalette } from './CommandPalette';

--- a/src/ui/foundation/GlobalStateProvider/GlobalStateProvider.tsx
+++ b/src/ui/foundation/GlobalStateProvider/GlobalStateProvider.tsx
@@ -1,9 +1,9 @@
 import React, { useRef } from 'react';
 
 import { useSettingsLastActiveVaultId } from '@/ui/hooks/query';
-import { UiMain } from '@/ui/uiMain';
 import { IpcUiService } from '@/ui/services/ipc/ipcUiService';
-import { GlobalStateContext } from './context';
+import { UiMain } from '@/ui/uiMain';
+import { CommandEventTarget, GlobalStateContext } from './context';
 
 interface Props {
   children: React.ReactNode;
@@ -18,11 +18,16 @@ function createUiMain() {
 // GlobalStateProvider provies the minimum context that is
 // required for the app to render.
 export function GlobalStateProvider({ children }: Props) {
-  const box = useRef<UiMain>();
-  if (!box.current) {
-    box.current = createUiMain();
-  }
-  const { data: activeVaultId } = useSettingsLastActiveVaultId(box.current);
+  const uiMainRef = useRef<UiMain>();
+  uiMainRef.current ??= createUiMain();
+
+  const commandEventTargetRef = useRef<CommandEventTarget>();
+  commandEventTargetRef.current ??= new CommandEventTarget();
+
+  const { data: activeVaultId } = useSettingsLastActiveVaultId(
+    uiMainRef.current
+  );
+
   if (!activeVaultId) {
     return <></>;
   }
@@ -31,7 +36,8 @@ export function GlobalStateProvider({ children }: Props) {
     <GlobalStateContext.Provider
       value={{
         activeVaultId,
-        uiMain: box.current,
+        commandEventTarget: commandEventTargetRef.current,
+        uiMain: uiMainRef.current,
       }}
     >
       {children}

--- a/src/ui/foundation/GlobalStateProvider/context.ts
+++ b/src/ui/foundation/GlobalStateProvider/context.ts
@@ -1,9 +1,12 @@
 import { createContext } from 'react';
 import { UiMain } from '@/ui/uiMain';
 
+export class CommandEventTarget extends EventTarget {}
+
 export interface GlobalState {
   activeVaultId: string;
   uiMain: UiMain;
+  commandEventTarget: CommandEventTarget;
 }
 
 export const GlobalStateContext = createContext<GlobalState>({} as GlobalState);

--- a/src/ui/foundation/SettingsProvider/context.ts
+++ b/src/ui/foundation/SettingsProvider/context.ts
@@ -25,6 +25,14 @@ export const defaultSettings: Settings = {
         console.log('HelloWorld');
       },
     },
+    {
+      id: 'command_palette',
+      name: 'Command Palette',
+      hotkeys: [
+        { modifiers: ['Control'], key: 'p' },
+        { modifiers: ['Meta'], key: 'p' },
+      ],
+    },
   ],
 };
 

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -2,3 +2,4 @@ export { useCommands } from './useCommands';
 export { useHotkeyListener } from './useHotkeyListener';
 export { useToggle } from './useToggle';
 export { useWindowDimensions } from './useWindowDimensions';
+export { useCommandListener } from './useCommandListener';

--- a/src/ui/hooks/useCommandListener.ts
+++ b/src/ui/hooks/useCommandListener.ts
@@ -1,0 +1,20 @@
+import { useContext, useEffect } from 'react';
+
+import { GlobalStateContext } from '@/ui/foundation/GlobalStateProvider';
+
+// TODO: add typing to command event name
+export function useCommandListener(
+  event: string,
+  on: () => void,
+  off: () => void = () => {}
+): void {
+  const { commandEventTarget } = useContext(GlobalStateContext);
+
+  useEffect(() => {
+    commandEventTarget.addEventListener(event, on);
+
+    return () => {
+      commandEventTarget.removeEventListener(event, off);
+    };
+  }, [commandEventTarget, on, off, event]);
+}

--- a/src/ui/hooks/useCommands.ts
+++ b/src/ui/hooks/useCommands.ts
@@ -1,8 +1,9 @@
 import { isEmpty } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 
 import { Command, Modifier } from '@/ui/foundation/SettingsProvider';
 import { hotkeyToString, isKey, isModifier } from '@/ui/utilities';
+import { GlobalStateContext } from '../foundation/GlobalStateProvider';
 
 /**
  * Bind commands hotkeys to keyboard event listener.
@@ -10,6 +11,7 @@ import { hotkeyToString, isKey, isModifier } from '@/ui/utilities';
  * @param commands
  */
 export function useCommands(commands: Command[]) {
+  const { commandEventTarget } = useContext(GlobalStateContext);
   const [modifiersPressed, setModifiersPressed] = useState<Modifier[]>([]);
   const [keyPressed, setKeyPressed] = useState<string | undefined>();
   const [activeCommand, setActiveCommand] = useState<Command>();
@@ -68,9 +70,13 @@ export function useCommands(commands: Command[]) {
   }, [modifiersPressed, keyPressed, activeCommand, registerCommandsHotkeys]);
 
   useEffect(() => {
-    // Trigger activeCommand callback if exists
-    if (activeCommand && activeCommand.callback) {
-      activeCommand.callback();
+    if (activeCommand) {
+      // Trigger activeCommand callback if exists
+      if (activeCommand.callback) {
+        activeCommand.callback();
+      }
+      // Dispatch command event
+      commandEventTarget.dispatchEvent(new CustomEvent(activeCommand.id));
     }
-  }, [activeCommand]);
+  }, [activeCommand, commandEventTarget]);
 }


### PR DESCRIPTION
Create a command palette that opens itself when the `command_palette` command event is dispatched.

![image](https://user-images.githubusercontent.com/22331097/180868596-c843097f-45c3-44fd-a50a-2673ddb07ddb.png)

In following PR: Fix keyboard accessibility in the command palette to properly manage arrow up, down and type filter text (and maybe include vim shortcuts ;) )