### PR TITLE
GlobalStateProvider: add uiMain

### DIFF
--- a/src/ui/foundation/GlobalStateProvider/GlobalStateProvider.tsx
+++ b/src/ui/foundation/GlobalStateProvider/GlobalStateProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useSettingsLastActiveVaultId } from '@/ui/hooks/query';
+import { uiMainInstance } from '@/ui/uiMain';
 import { GlobalStateContext } from './context';
 
 interface Props {
@@ -16,7 +17,12 @@ export function GlobalStateProvider({ children }: Props) {
   }
 
   return (
-    <GlobalStateContext.Provider value={{ activeVaultId }}>
+    <GlobalStateContext.Provider
+      value={{
+        activeVaultId,
+        uiMain: uiMainInstance,
+      }}
+    >
       {children}
     </GlobalStateContext.Provider>
   );

--- a/src/ui/foundation/GlobalStateProvider/context.ts
+++ b/src/ui/foundation/GlobalStateProvider/context.ts
@@ -1,11 +1,14 @@
 import { createContext } from 'react';
+import { UiMain, uiMainInstance } from '@/ui/uiMain';
 
 export interface GlobalState {
   activeVaultId: string;
+  uiMain: UiMain;
 }
 
 export const defaultGlobalState: GlobalState = {
   activeVaultId: '',
+  uiMain: uiMainInstance,
 };
 
 export const GlobalStateContext =

--- a/src/ui/foundation/MainLayout/components/TopBar/TopBar.tsx
+++ b/src/ui/foundation/MainLayout/components/TopBar/TopBar.tsx
@@ -8,13 +8,15 @@ import {
 import { IconButton, Toolbar, Typography, useTheme } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 
-import { uiMain } from '@/ui/index';
 import { IpcWorkerMessageType } from '@/lib/ipc/ipcWorker';
 import { useSettingsLastActiveVaultId } from '@/ui/hooks/query';
+import { GlobalStateContext } from '@/ui/foundation/GlobalStateProvider';
+import { useContext } from 'react';
 
 export function TopBar() {
   const theme = useTheme();
   const navigate = useNavigate();
+  const { uiMain } = useContext(GlobalStateContext);
 
   // TODO: Improve navigation
   // Find if there's a previous or next path in the stack, so we can disable the button when unavailable

--- a/src/ui/hooks/query/useSettingsLastActiveVaultId.ts
+++ b/src/ui/hooks/query/useSettingsLastActiveVaultId.ts
@@ -1,9 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
-import { uiMain } from '@/ui/index';
 import { IpcWorkerMessageType } from '@/lib/ipc/ipcWorker';
+import { useContext } from 'react';
+import { GlobalStateContext } from '@/ui/foundation/GlobalStateProvider';
+import { UiMain } from '@/ui/uiMain';
 import { QueryKey } from './keys';
 
-const getSettingsLastActiveVaultId = async (): Promise<string | null> => {
+const getSettingsLastActiveVaultId = async (
+  uiMain: UiMain
+): Promise<string | null> => {
   const resp = await uiMain.workerInvoke({
     type: IpcWorkerMessageType.SETTINGS_GET_LAST_ACTIVE_VAULT_ID,
   });
@@ -11,5 +15,8 @@ const getSettingsLastActiveVaultId = async (): Promise<string | null> => {
 };
 
 export function useSettingsLastActiveVaultId() {
-  return useQuery([QueryKey.VAULT_PAGES], () => getSettingsLastActiveVaultId());
+  const { uiMain } = useContext(GlobalStateContext);
+  return useQuery([QueryKey.VAULT_PAGES], () =>
+    getSettingsLastActiveVaultId(uiMain)
+  );
 }

--- a/src/ui/hooks/query/useVaultPages.ts
+++ b/src/ui/hooks/query/useVaultPages.ts
@@ -1,9 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
-import { uiMain } from '@/ui/index';
 import { IpcWorkerMessageType } from '@/lib/ipc/ipcWorker';
+import { GlobalStateContext } from '@/ui/foundation/GlobalStateProvider';
+import { useContext } from 'react';
+import { UiMain } from '@/ui/uiMain';
 import { QueryKey } from './keys';
 
-const getVaultPages = async (vauldId: string): Promise<string[]> => {
+const getVaultPages = async (
+  uiMain: UiMain,
+  vauldId: string
+): Promise<string[]> => {
   const resp = await uiMain.workerInvoke({
     type: IpcWorkerMessageType.VAULT_GET_FILES,
     vaultId: vauldId,
@@ -12,7 +17,8 @@ const getVaultPages = async (vauldId: string): Promise<string[]> => {
 };
 
 export function useVaultPages(vaultId: string) {
+  const { uiMain } = useContext(GlobalStateContext);
   return useQuery([QueryKey.VAULT_PAGES, vaultId], () =>
-    getVaultPages(vaultId)
+    getVaultPages(uiMain, vaultId)
   );
 }

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -2,8 +2,6 @@ import { createRoot } from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
 
 import App from './foundation/App';
-import { UiMain } from './uiMain';
-import { IpcUiService } from './services/ipc/ipcUiService';
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const container = document.getElementById('root')!;
@@ -13,6 +11,3 @@ root.render(
     <App />
   </MemoryRouter>
 );
-
-export const uiMain = new UiMain(new IpcUiService());
-uiMain.main();

--- a/src/ui/uiMain.ts
+++ b/src/ui/uiMain.ts
@@ -44,3 +44,6 @@ export class UiMain {
     return this.ipcUiService.workerInvoke(message);
   }
 }
+
+export const uiMainInstance = new UiMain(new IpcUiService());
+uiMainInstance.main();


### PR DESCRIPTION
- Moved the uiMain pointer to GlobalState
- No longer start uiMain from `index.tsx`
- This feels more react-ish. The components don't have to import a global anymore.
- Also more testable, we can instantiate components with a provider providing a mock.
- Everything else still works the same.
- Renamed the `uiMain` instance to `uiMainInstance` just to avoid people importing it by mistake in cases where what they really wanted was the class. Nobody should import that instance anymore, except for the provider.