### PR TITLE
worker ipc: settings -> configuration

### DIFF
--- a/src/lib/ipc/ipcWorker.ts
+++ b/src/lib/ipc/ipcWorker.ts
@@ -12,10 +12,10 @@ export enum IpcWorkerMessageType {
   WINDOWS_MINIMIZE = 'windows:minimize',
   WINDOWS_MAXIMIZE = 'windows:maximize',
   WINDOWS_QUIT = 'windows:quit',
-  // **************
-  // ** SETTINGS **
-  // **************
-  SETTINGS_GET_LAST_ACTIVE_VAULT_ID = 'settings:getLastActiveVaultId',
+  // *******************
+  // ** CONFIGURATION **
+  // *******************
+  CONFIGURATION_GET_LAST_ACTIVE_VAULT_ID = 'configuration:getLastActiveVaultId',
   // ***********
   // ** VAULT **
   // ***********
@@ -76,12 +76,12 @@ type IpcWorkerMessages =
       };
       response: null;
     }
-  // **************
-  // ** SETTINGS **
-  // **************
+  // *******************
+  // ** CONFIGURATION **
+  // *******************
   | {
       request: {
-        type: IpcWorkerMessageType.SETTINGS_GET_LAST_ACTIVE_VAULT_ID;
+        type: IpcWorkerMessageType.CONFIGURATION_GET_LAST_ACTIVE_VAULT_ID;
       };
       response: {
         vaultId: string | null;

--- a/src/ui/hooks/query/index.ts
+++ b/src/ui/hooks/query/index.ts
@@ -1,3 +1,3 @@
 export { useVaultPages } from './useVaultPages';
-export { useSettingsLastActiveVaultId } from './useSettingsLastActiveVaultId';
+export { useSettingsLastActiveVaultId } from './useConfigurationLastActiveVaultId';
 export { QueryKey } from './keys';

--- a/src/ui/hooks/query/useConfigurationLastActiveVaultId.ts
+++ b/src/ui/hooks/query/useConfigurationLastActiveVaultId.ts
@@ -3,11 +3,11 @@ import { IpcWorkerMessageType } from '@/lib/ipc/ipcWorker';
 import { UiMain } from '@/ui/uiMain';
 import { QueryKey } from './keys';
 
-const getSettingsLastActiveVaultId = async (
+const getConfigurationLastActiveVaultId = async (
   uiMain: UiMain
 ): Promise<string | null> => {
   const resp = await uiMain.workerInvoke({
-    type: IpcWorkerMessageType.SETTINGS_GET_LAST_ACTIVE_VAULT_ID,
+    type: IpcWorkerMessageType.CONFIGURATION_GET_LAST_ACTIVE_VAULT_ID,
   });
   return resp.vaultId;
 };
@@ -17,6 +17,6 @@ export function useSettingsLastActiveVaultId(uiMain: UiMain) {
   // This is because it is used by the GlobalStateProvider, which can't
   // use his own context.
   return useQuery([QueryKey.VAULT_PAGES], () =>
-    getSettingsLastActiveVaultId(uiMain)
+    getConfigurationLastActiveVaultId(uiMain)
   );
 }

--- a/src/worker/workerMain.ts
+++ b/src/worker/workerMain.ts
@@ -80,10 +80,10 @@ export class WorkerMain {
           const resp: IpcWorkerResponseOf<typeof messageType> = null;
           return resp;
         }
-        // **************
-        // ** SETTINGS **
-        // **************
-        case IpcWorkerMessageType.SETTINGS_GET_LAST_ACTIVE_VAULT_ID: {
+        // *******************
+        // ** CONFIGURATION **
+        // *******************
+        case IpcWorkerMessageType.CONFIGURATION_GET_LAST_ACTIVE_VAULT_ID: {
           const vaultConfig =
             await configurationService.getVaultConfiguration();
           const resp: IpcWorkerResponseOf<typeof messageType> = {


### PR DESCRIPTION
I don't know why I started naming things using `settings`. The service that handles these API calls is called `configurationService`.

Let's use `configuration` everywhere.

At some point `configurationService` will have a `getVaultSettings` or something, which does not exist yet.